### PR TITLE
feat: add new probe to the board

### DIFF
--- a/engineering/network/cardworks.json
+++ b/engineering/network/cardworks.json
@@ -105,9 +105,16 @@
             "targets": [
                 {
                     "exemplar": true,
+                    "expr": "sum (probe_success{target=\"cardworks-through-vgs-proxy-http\"})",
+                    "interval": "",
+                    "legendFormat": "Cardworks HTTP probes through VGS proxy",
+                    "refId": "HTTP probes through VGS proxy"
+                },
+                {
+                    "exemplar": true,
                     "expr": "sum (probe_success{target=\"cardworks-through-fnx-proxy\"})",
                     "interval": "",
-                    "legendFormat": "Cardworks HTTP probes",
+                    "legendFormat": "Cardworks HTTP probes through Peplink VPN",
                     "refId": "HTTP probes"
                 },
                 {
@@ -115,7 +122,7 @@
                     "expr": "sum (probe_success{target=\"cardworks-through-fnx-proxy-tcp\"})",
                     "hide": false,
                     "interval": "",
-                    "legendFormat": "Cardworks TCP probes",
+                    "legendFormat": "Cardworks TCP probes through Peplink VPN",
                     "refId": "TCP probes"
                 },
                 {
@@ -125,14 +132,6 @@
                     "interval": "",
                     "legendFormat": "VGS proxy TCP probes",
                     "refId": "VGS TCP probes"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "sum (probe_success{target=\"cardworks-through-legacy-network\"})",
-                    "hide": false,
-                    "interval": "",
-                    "legendFormat": "Cardworks through legacy network",
-                    "refId": "cardworks through legacy network"
                 }
             ],
             "title": "Cardworks network reacheability",


### PR DESCRIPTION
* Remove old metric that was based on the traffic through legacy 'transit-network' that now is deprecated.
* Adds new metric to the board, matching a newly created probe `cardworks-through-vgs-proxy-http`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/grafana-dashboards/8)
<!-- Reviewable:end -->
